### PR TITLE
chore: Remove dead code paths for deprecated native_comet scan

### DIFF
--- a/.github/actions/java-test/action.yaml
+++ b/.github/actions/java-test/action.yaml
@@ -32,7 +32,7 @@ inputs:
   scan_impl:
     description: 'The default Parquet scan implementation'
     required: false
-    default: 'native_comet'
+    default: 'auto'
   upload-test-reports:
     description: 'Whether to upload test results including coverage to GitHub'
     required: false

--- a/.github/workflows/pr_build_linux.yml
+++ b/.github/workflows/pr_build_linux.yml
@@ -164,7 +164,7 @@ jobs:
           - name: "Spark 3.4, JDK 11, Scala 2.12"
             java_version: "11"
             maven_opts: "-Pspark-3.4 -Pscala-2.12"
-            scan_impl: "native_comet"
+            scan_impl: "auto"
 
           - name: "Spark 3.5.5, JDK 17, Scala 2.13"
             java_version: "17"
@@ -174,7 +174,7 @@ jobs:
           - name: "Spark 3.5.6, JDK 17, Scala 2.13"
             java_version: "17"
             maven_opts: "-Pspark-3.5 -Dspark.version=3.5.6 -Pscala-2.13"
-            scan_impl: "native_comet"
+            scan_impl: "auto"
 
           - name: "Spark 3.5, JDK 17, Scala 2.12"
             java_version: "17"

--- a/.github/workflows/spark_sql_test.yml
+++ b/.github/workflows/spark_sql_test.yml
@@ -116,15 +116,12 @@ jobs:
           - {name: "sql_hive-3", args1: "", args2: "hive/testOnly * -- -n org.apache.spark.tags.SlowHiveTest"}
         # Test combinations:
         # - auto scan: all Spark versions (3.4, 3.5, 4.0)
-        # - native_comet: Spark 3.4, 3.5
         # - native_iceberg_compat: Spark 3.5 only
         config:
           - {spark-short: '3.4', spark-full: '3.4.3', java: 11, scan-impl: 'auto', scan-env: ''}
           - {spark-short: '3.5', spark-full: '3.5.8', java: 11, scan-impl: 'auto', scan-env: ''}
-          - {spark-short: '4.0', spark-full: '4.0.1', java: 17, scan-impl: 'auto', scan-env: ''}
-          - {spark-short: '3.4', spark-full: '3.4.3', java: 11, scan-impl: 'native_comet', scan-env: 'COMET_PARQUET_SCAN_IMPL=native_comet'}
-          - {spark-short: '3.5', spark-full: '3.5.8', java: 11, scan-impl: 'native_comet', scan-env: 'COMET_PARQUET_SCAN_IMPL=native_comet'}
           - {spark-short: '3.5', spark-full: '3.5.8', java: 11, scan-impl: 'native_iceberg_compat', scan-env: 'COMET_PARQUET_SCAN_IMPL=native_iceberg_compat'}
+          - {spark-short: '4.0', spark-full: '4.0.1', java: 17, scan-impl: 'auto', scan-env: ''}
         # Skip sql_hive-1 for Spark 4.0 due to https://github.com/apache/datafusion-comet/issues/2946
         exclude:
           - config: {spark-short: '4.0', spark-full: '4.0.1', java: 17, scan-impl: 'auto', scan-env: ''}

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ format:
 
 # build native libs for amd64 architecture Linux/MacOS on a Linux/amd64 machine/container
 core-amd64-libs:
-	cd native && cargo build -j 2 --release $(FEATURES_ARG)
+	cd native && RUSTFLAGS="-Ctarget-cpu=x86-64-v3" cargo build -j 2 --release $(FEATURES_ARG)
 ifdef HAS_OSXCROSS
 	rustup target add x86_64-apple-darwin
 	cd native && cargo build -j 2 --target x86_64-apple-darwin --release $(FEATURES_ARG)
@@ -59,7 +59,7 @@ endif
 
 # build native libs for arm64 architecture Linux/MacOS on a Linux/arm64 machine/container
 core-arm64-libs:
-	cd native && cargo build -j 2 --release $(FEATURES_ARG)
+	cd native && RUSTFLAGS="-Ctarget-cpu=neoverse-n1" cargo build -j 2 --release $(FEATURES_ARG)
 ifdef HAS_OSXCROSS
 	rustup target add aarch64-apple-darwin
 	cd native && cargo build -j 2 --target aarch64-apple-darwin --release $(FEATURES_ARG)
@@ -67,10 +67,10 @@ endif
 
 core-amd64:
 	rustup target add x86_64-apple-darwin
-	cd native && RUSTFLAGS="-Ctarget-cpu=skylake -Ctarget-feature=-prefer-256-bit" CC=o64-clang CXX=o64-clang++ cargo build --target x86_64-apple-darwin --release $(FEATURES_ARG)
+	cd native && RUSTFLAGS="-Ctarget-cpu=skylake" CC=o64-clang CXX=o64-clang++ cargo build --target x86_64-apple-darwin --release $(FEATURES_ARG)
 	mkdir -p common/target/classes/org/apache/comet/darwin/x86_64
 	cp native/target/x86_64-apple-darwin/release/libcomet.dylib common/target/classes/org/apache/comet/darwin/x86_64
-	cd native && RUSTFLAGS="-Ctarget-cpu=haswell -Ctarget-feature=-prefer-256-bit" cargo build --release $(FEATURES_ARG)
+	cd native && RUSTFLAGS="-Ctarget-cpu=x86-64-v3" cargo build --release $(FEATURES_ARG)
 	mkdir -p common/target/classes/org/apache/comet/linux/amd64
 	cp native/target/release/libcomet.so common/target/classes/org/apache/comet/linux/amd64
 	jar -cf common/target/comet-native-x86_64.jar \
@@ -83,7 +83,7 @@ core-arm64:
 	cd native && RUSTFLAGS="-Ctarget-cpu=apple-m1" CC=arm64-apple-darwin21.4-clang CXX=arm64-apple-darwin21.4-clang++ CARGO_FEATURE_NEON=1 cargo build --target aarch64-apple-darwin --release $(FEATURES_ARG)
 	mkdir -p common/target/classes/org/apache/comet/darwin/aarch64
 	cp native/target/aarch64-apple-darwin/release/libcomet.dylib common/target/classes/org/apache/comet/darwin/aarch64
-	cd native && RUSTFLAGS="-Ctarget-cpu=native" cargo build --release $(FEATURES_ARG)
+	cd native && RUSTFLAGS="-Ctarget-cpu=neoverse-n1" cargo build --release $(FEATURES_ARG)
 	mkdir -p common/target/classes/org/apache/comet/linux/aarch64
 	cp native/target/release/libcomet.so common/target/classes/org/apache/comet/linux/aarch64
 	jar -cf common/target/comet-native-aarch64.jar \
@@ -94,8 +94,8 @@ core-arm64:
 release-linux: clean
 	rustup target add aarch64-apple-darwin x86_64-apple-darwin
 	cd native && RUSTFLAGS="-Ctarget-cpu=apple-m1" CC=arm64-apple-darwin21.4-clang CXX=arm64-apple-darwin21.4-clang++ CARGO_FEATURE_NEON=1 cargo build --target aarch64-apple-darwin --release $(FEATURES_ARG)
-	cd native && RUSTFLAGS="-Ctarget-cpu=skylake -Ctarget-feature=-prefer-256-bit" CC=o64-clang CXX=o64-clang++ cargo build --target x86_64-apple-darwin --release $(FEATURES_ARG)
-	cd native && RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=-prefer-256-bit" cargo build --release $(FEATURES_ARG)
+	cd native && RUSTFLAGS="-Ctarget-cpu=skylake" CC=o64-clang CXX=o64-clang++ cargo build --target x86_64-apple-darwin --release $(FEATURES_ARG)
+	cd native && RUSTFLAGS="-Ctarget-cpu=native" cargo build --release $(FEATURES_ARG)
 	./mvnw install -Prelease -DskipTests $(PROFILES)
 release:
 	cd native && RUSTFLAGS="$(RUSTFLAGS) -Ctarget-cpu=native" cargo build --release $(FEATURES_ARG)

--- a/common/src/main/scala/org/apache/comet/CometConf.scala
+++ b/common/src/main/scala/org/apache/comet/CometConf.scala
@@ -124,11 +124,8 @@ object CometConf extends ShimCometConf {
   val COMET_NATIVE_SCAN_IMPL: ConfigEntry[String] = conf("spark.comet.scan.impl")
     .category(CATEGORY_SCAN)
     .doc(
-      s"The implementation of Comet Native Scan to use. Available modes are `$SCAN_NATIVE_COMET`," +
+      "The implementation of Comet Native Scan to use. Available modes are " +
         s"`$SCAN_NATIVE_DATAFUSION`, and `$SCAN_NATIVE_ICEBERG_COMPAT`. " +
-        s"`$SCAN_NATIVE_COMET` (DEPRECATED - will be removed in a future release) is for the " +
-        "original Comet native scan which uses a jvm based parquet file reader and native " +
-        "column decoding. Supports simple types only. " +
         s"`$SCAN_NATIVE_DATAFUSION` is a fully native implementation of scan based on " +
         "DataFusion. " +
         s"`$SCAN_NATIVE_ICEBERG_COMPAT` is the recommended native implementation that " +
@@ -137,8 +134,7 @@ object CometConf extends ShimCometConf {
     .internal()
     .stringConf
     .transform(_.toLowerCase(Locale.ROOT))
-    .checkValues(
-      Set(SCAN_NATIVE_COMET, SCAN_NATIVE_DATAFUSION, SCAN_NATIVE_ICEBERG_COMPAT, SCAN_AUTO))
+    .checkValues(Set(SCAN_NATIVE_DATAFUSION, SCAN_NATIVE_ICEBERG_COMPAT, SCAN_AUTO))
     .createWithEnvVarOrDefault("COMET_PARQUET_SCAN_IMPL", SCAN_AUTO)
 
   val COMET_ICEBERG_NATIVE_ENABLED: ConfigEntry[Boolean] =

--- a/dev/diffs/3.4.3.diff
+++ b/dev/diffs/3.4.3.diff
@@ -1157,7 +1157,7 @@ index cfc8b2cc845..c6fcfd7bd08 100644
  import org.apache.spark.SparkConf
  import org.apache.spark.sql.{AnalysisException, QueryTest}
  import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-+import org.apache.spark.sql.comet.CometScanExec
++import org.apache.spark.sql.comet.{CometNativeScanExec, CometScanExec}
  import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
  import org.apache.spark.sql.connector.read.ScanBuilder
  import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
@@ -1167,7 +1167,7 @@ index cfc8b2cc845..c6fcfd7bd08 100644
              assert(
 -              df.queryExecution.executedPlan.exists(_.isInstanceOf[FileSourceScanExec]))
 +              df.queryExecution.executedPlan.exists {
-+                case _: FileSourceScanExec | _: CometScanExec => true
++                case _: FileSourceScanExec | _: CometScanExec | _: CometNativeScanExec => true
 +                case _ => false
 +              }
 +            )

--- a/dev/diffs/3.5.8.diff
+++ b/dev/diffs/3.5.8.diff
@@ -1111,7 +1111,7 @@ index cfc8b2cc845..c6fcfd7bd08 100644
  import org.apache.spark.SparkConf
  import org.apache.spark.sql.{AnalysisException, QueryTest}
  import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-+import org.apache.spark.sql.comet.CometScanExec
++import org.apache.spark.sql.comet.{CometNativeScanExec, CometScanExec}
  import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
  import org.apache.spark.sql.connector.read.ScanBuilder
  import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
@@ -1121,7 +1121,7 @@ index cfc8b2cc845..c6fcfd7bd08 100644
              assert(
 -              df.queryExecution.executedPlan.exists(_.isInstanceOf[FileSourceScanExec]))
 +              df.queryExecution.executedPlan.exists {
-+                case _: FileSourceScanExec | _: CometScanExec => true
++                case _: FileSourceScanExec | _: CometScanExec | _: CometNativeScanExec => true
 +                case _ => false
 +              }
 +            )

--- a/dev/diffs/4.0.1.diff
+++ b/dev/diffs/4.0.1.diff
@@ -1443,7 +1443,7 @@ index 2a0ab21ddb0..e8a5a891105 100644
  import org.apache.spark.{SparkConf, SparkException}
  import org.apache.spark.sql.QueryTest
  import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-+import org.apache.spark.sql.comet.CometScanExec
++import org.apache.spark.sql.comet.{CometNativeScanExec, CometScanExec}
  import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, Table, TableCapability}
  import org.apache.spark.sql.connector.read.ScanBuilder
  import org.apache.spark.sql.connector.write.{LogicalWriteInfo, WriteBuilder}
@@ -1453,7 +1453,7 @@ index 2a0ab21ddb0..e8a5a891105 100644
              assert(
 -              df.queryExecution.executedPlan.exists(_.isInstanceOf[FileSourceScanExec]))
 +              df.queryExecution.executedPlan.exists {
-+                case _: FileSourceScanExec | _: CometScanExec => true
++                case _: FileSourceScanExec | _: CometScanExec | _: CometNativeScanExec => true
 +                case _ => false
 +              }
 +            )

--- a/docs/source/user-guide/latest/installation.md
+++ b/docs/source/user-guide/latest/installation.md
@@ -60,6 +60,12 @@ Cloud Service Providers.
 Comet jar files are available in [Maven Central](https://central.sonatype.com/namespace/org.apache.datafusion) for amd64 and arm64 architectures for Linux. For Apple macOS, it
 is currently necessary to build from source.
 
+For performance reasons, published Comet jar files target baseline CPUs available in modern data centers. For example,
+the amd64 build uses the `x86-64-v3` target that adds CPU instructions (_e.g._, AVX2) common after 2013. Similarly, the
+arm64 build uses the `neoverse-n1` target, which is a common baseline for ARM cores found in AWS (Graviton2+), GCP, and
+Azure after 2019. If the Comet library fails for SIGILL (illegal instruction), please open an issue on the GitHub
+repository describing your environment, and [build from source] for your target architecture.
+
 Here are the direct links for downloading the Comet $COMET_VERSION jar file. Note that these links are not valid if
 you are viewing the documentation for the latest `SNAPSHOT` release, or for the latest release while it is still going
 through the release vote. Release candidate jars can be found [here](https://repository.apache.org/#nexus-search;quick~org.apache.datafusion).
@@ -72,10 +78,10 @@ through the release vote. Release candidate jars can be found [here](https://rep
 
 ## Building from source
 
-Refer to the [Building from Source] guide for instructions from building Comet from source, either from official
+Refer to the [Building from source] guide for instructions from building Comet from source, either from official
 source releases, or from the latest code in the GitHub repository.
 
-[Building from Source]: source.md
+[Building from source]: source.md
 
 ## Deploying to Kubernetes
 

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -1192,9 +1192,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytes-utils"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -36,7 +36,7 @@ rust-version = "1.88"
 [workspace.dependencies]
 arrow = { version = "57.2.0", features = ["prettyprint", "ffi", "chrono-tz"] }
 async-trait = { version = "0.1" }
-bytes = { version = "1.10.0" }
+bytes = { version = "1.11.1" }
 parquet = { version = "57.2.0", default-features = false, features = ["experimental"] }
 datafusion = { version = "51.0.0", default-features = false, features = ["unicode_expressions", "crypto_expressions", "nested_expressions", "parquet"] }
 datafusion-datasource = { version = "51.0.0" }

--- a/native/core/src/execution/shuffle/shuffle_writer.rs
+++ b/native/core/src/execution/shuffle/shuffle_writer.rs
@@ -18,10 +18,12 @@
 //! Defines the External shuffle repartition plan.
 
 use crate::execution::shuffle::metrics::ShufflePartitionerMetrics;
+use crate::execution::shuffle::writers::{BufBatchWriter, PartitionWriter};
 use crate::execution::shuffle::{CometPartitioning, CompressionCodec, ShuffleBlockWriter};
 use crate::execution::tracing::{with_trace, with_trace_async};
 use arrow::compute::interleave_record_batch;
 use async_trait::async_trait;
+use datafusion::common::exec_datafusion_err;
 use datafusion::common::utils::proxy::VecAllocExt;
 use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
@@ -31,7 +33,6 @@ use datafusion::{
     error::{DataFusionError, Result},
     execution::{
         context::TaskContext,
-        disk_manager::RefCountedTempFile,
         memory_pool::{MemoryConsumer, MemoryReservation},
         runtime_env::RuntimeEnv,
     },
@@ -45,8 +46,6 @@ use datafusion::{
 use datafusion_comet_spark_expr::hash_funcs::murmur3::create_murmur3_hashes;
 use futures::{StreamExt, TryFutureExt, TryStreamExt};
 use itertools::Itertools;
-use std::borrow::Borrow;
-use std::io::{Cursor, Error, SeekFrom};
 use std::{
     any::Any,
     fmt,
@@ -256,10 +255,15 @@ async fn external_shuffle(
             // into the corresponding partition buffer.
             // Otherwise, pull the next batch from the input stream might overwrite the
             // current batch in the repartitioner.
-            repartitioner.insert_batch(batch?).await?;
+            repartitioner
+                .insert_batch(batch?)
+                .await
+                .map_err(|err| exec_datafusion_err!("Error inserting batch: {err}"))?;
         }
 
-        repartitioner.shuffle_write()?;
+        repartitioner
+            .shuffle_write()
+            .map_err(|err| exec_datafusion_err!("Error in shuffle write: {err}"))?;
 
         // shuffle writer always has empty output
         Ok(Box::pin(EmptyRecordBatchStream::new(Arc::clone(&schema))) as SendableRecordBatchStream)
@@ -803,11 +807,10 @@ impl ShufflePartitioner for MultiPartitionShuffleRepartitioner {
 
                 // if we wrote a spill file for this partition then copy the
                 // contents into the shuffle file
-                if let Some(spill_data) = self.partition_writers[i].spill_file.as_ref() {
-                    let mut spill_file =
-                        BufReader::new(File::open(spill_data.temp_file.path()).map_err(to_df_err)?);
+                if let Some(spill_path) = self.partition_writers[i].path() {
+                    let mut spill_file = BufReader::new(File::open(spill_path)?);
                     let mut write_timer = self.metrics.write_time.timer();
-                    std::io::copy(&mut spill_file, &mut output_data).map_err(to_df_err)?;
+                    std::io::copy(&mut spill_file, &mut output_data)?;
                     write_timer.stop();
                 }
 
@@ -828,7 +831,7 @@ impl ShufflePartitioner for MultiPartitionShuffleRepartitioner {
             write_timer.stop();
 
             // add one extra offset at last to ease partition length computation
-            offsets[num_output_partitions] = output_data.stream_position().map_err(to_df_err)?;
+            offsets[num_output_partitions] = output_data.stream_position()?;
 
             let mut write_timer = self.metrics.write_time.timer();
             let mut output_index =
@@ -836,9 +839,7 @@ impl ShufflePartitioner for MultiPartitionShuffleRepartitioner {
                     DataFusionError::Execution(format!("shuffle write error: {e:?}"))
                 })?);
             for offset in offsets {
-                output_index
-                    .write_all(&(offset as i64).to_le_bytes()[..])
-                    .map_err(to_df_err)?;
+                output_index.write_all(&(offset as i64).to_le_bytes()[..])?;
             }
             output_index.flush()?;
             write_timer.stop();
@@ -895,8 +896,7 @@ impl SinglePartitionShufflePartitioner {
             .write(true)
             .create(true)
             .truncate(true)
-            .open(output_data_path)
-            .map_err(to_df_err)?;
+            .open(output_data_path)?;
 
         let output_data_writer =
             BufBatchWriter::new(shuffle_block_writer, output_data_file, write_buffer_size);
@@ -1011,15 +1011,9 @@ impl ShufflePartitioner for SinglePartitionShufflePartitioner {
             .open(self.output_index_path.clone())
             .map_err(|e| DataFusionError::Execution(format!("shuffle write error: {e:?}")))?;
         let mut index_buf_writer = BufWriter::new(index_file);
-        let data_file_length = self
-            .output_data_writer
-            .writer
-            .stream_position()
-            .map_err(to_df_err)?;
+        let data_file_length = self.output_data_writer.writer_stream_position()?;
         for offset in [0, data_file_length] {
-            index_buf_writer
-                .write_all(&(offset as i64).to_le_bytes()[..])
-                .map_err(to_df_err)?;
+            index_buf_writer.write_all(&(offset as i64).to_le_bytes()[..])?;
         }
         index_buf_writer.flush()?;
 
@@ -1031,21 +1025,17 @@ impl ShufflePartitioner for SinglePartitionShufflePartitioner {
     }
 }
 
-fn to_df_err(e: Error) -> DataFusionError {
-    DataFusionError::Execution(format!("shuffle write error: {e:?}"))
-}
-
 /// A helper struct to produce shuffled batches.
 /// This struct takes ownership of the buffered batches and partition indices from the
 /// ShuffleRepartitioner, and provides an iterator over the batches in the specified partitions.
-struct PartitionedBatchesProducer {
+pub(crate) struct PartitionedBatchesProducer {
     buffered_batches: Vec<RecordBatch>,
     partition_indices: Vec<Vec<(u32, u32)>>,
     batch_size: usize,
 }
 
 impl PartitionedBatchesProducer {
-    fn new(
+    pub(crate) fn new(
         buffered_batches: Vec<RecordBatch>,
         indices: Vec<Vec<(u32, u32)>>,
         batch_size: usize,
@@ -1066,7 +1056,7 @@ impl PartitionedBatchesProducer {
     }
 }
 
-struct PartitionedBatchIterator<'a> {
+pub(crate) struct PartitionedBatchIterator<'a> {
     record_batches: Vec<&'a RecordBatch>,
     batch_size: usize,
     indices: Vec<(usize, usize)>,
@@ -1122,141 +1112,6 @@ impl Iterator for PartitionedBatchIterator<'_> {
                 Some(DataFusionError::get_back_trace()),
             ))),
         }
-    }
-}
-
-struct PartitionWriter {
-    /// Spill file for intermediate shuffle output for this partition. Each spill event
-    /// will append to this file and the contents will be copied to the shuffle file at
-    /// the end of processing.
-    spill_file: Option<SpillFile>,
-    /// Writer that performs encoding and compression
-    shuffle_block_writer: ShuffleBlockWriter,
-}
-
-struct SpillFile {
-    temp_file: RefCountedTempFile,
-    file: File,
-}
-
-impl PartitionWriter {
-    fn try_new(shuffle_block_writer: ShuffleBlockWriter) -> Result<Self> {
-        Ok(Self {
-            spill_file: None,
-            shuffle_block_writer,
-        })
-    }
-
-    fn spill(
-        &mut self,
-        iter: &mut PartitionedBatchIterator,
-        runtime: &RuntimeEnv,
-        metrics: &ShufflePartitionerMetrics,
-        write_buffer_size: usize,
-    ) -> Result<usize> {
-        if let Some(batch) = iter.next() {
-            self.ensure_spill_file_created(runtime)?;
-
-            let total_bytes_written = {
-                let mut buf_batch_writer = BufBatchWriter::new(
-                    &mut self.shuffle_block_writer,
-                    &mut self.spill_file.as_mut().unwrap().file,
-                    write_buffer_size,
-                );
-                let mut bytes_written =
-                    buf_batch_writer.write(&batch?, &metrics.encode_time, &metrics.write_time)?;
-                for batch in iter {
-                    let batch = batch?;
-                    bytes_written += buf_batch_writer.write(
-                        &batch,
-                        &metrics.encode_time,
-                        &metrics.write_time,
-                    )?;
-                }
-                buf_batch_writer.flush(&metrics.write_time)?;
-                bytes_written
-            };
-
-            Ok(total_bytes_written)
-        } else {
-            Ok(0)
-        }
-    }
-
-    fn ensure_spill_file_created(&mut self, runtime: &RuntimeEnv) -> Result<()> {
-        if self.spill_file.is_none() {
-            // Spill file is not yet created, create it
-            let spill_file = runtime
-                .disk_manager
-                .create_tmp_file("shuffle writer spill")?;
-            let spill_data = OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(spill_file.path())
-                .map_err(|e| {
-                    DataFusionError::Execution(format!("Error occurred while spilling {e}"))
-                })?;
-            self.spill_file = Some(SpillFile {
-                temp_file: spill_file,
-                file: spill_data,
-            });
-        }
-        Ok(())
-    }
-}
-
-/// Write batches to writer while using a buffer to avoid frequent system calls.
-/// The record batches were first written by ShuffleBlockWriter into an internal buffer.
-/// Once the buffer exceeds the max size, the buffer will be flushed to the writer.
-struct BufBatchWriter<S: Borrow<ShuffleBlockWriter>, W: Write> {
-    shuffle_block_writer: S,
-    writer: W,
-    buffer: Vec<u8>,
-    buffer_max_size: usize,
-}
-
-impl<S: Borrow<ShuffleBlockWriter>, W: Write> BufBatchWriter<S, W> {
-    fn new(shuffle_block_writer: S, writer: W, buffer_max_size: usize) -> Self {
-        Self {
-            shuffle_block_writer,
-            writer,
-            buffer: vec![],
-            buffer_max_size,
-        }
-    }
-
-    fn write(
-        &mut self,
-        batch: &RecordBatch,
-        encode_time: &Time,
-        write_time: &Time,
-    ) -> Result<usize> {
-        let mut cursor = Cursor::new(&mut self.buffer);
-        cursor.seek(SeekFrom::End(0))?;
-        let bytes_written =
-            self.shuffle_block_writer
-                .borrow()
-                .write_batch(batch, &mut cursor, encode_time)?;
-        let pos = cursor.position();
-        if pos >= self.buffer_max_size as u64 {
-            let mut write_timer = write_time.timer();
-            self.writer.write_all(&self.buffer)?;
-            write_timer.stop();
-            self.buffer.clear();
-        }
-        Ok(bytes_written)
-    }
-
-    fn flush(&mut self, write_time: &Time) -> Result<()> {
-        let mut write_timer = write_time.timer();
-        if !self.buffer.is_empty() {
-            self.writer.write_all(&self.buffer)?;
-        }
-        self.writer.flush()?;
-        write_timer.stop();
-        self.buffer.clear();
-        Ok(())
     }
 }
 
@@ -1371,14 +1226,14 @@ mod test {
 
         assert_eq!(2, repartitioner.partition_writers.len());
 
-        assert!(repartitioner.partition_writers[0].spill_file.is_none());
-        assert!(repartitioner.partition_writers[1].spill_file.is_none());
+        assert!(!repartitioner.partition_writers[0].has_spill_file());
+        assert!(!repartitioner.partition_writers[1].has_spill_file());
 
         repartitioner.spill().unwrap();
 
         // after spill, there should be spill files
-        assert!(repartitioner.partition_writers[0].spill_file.is_some());
-        assert!(repartitioner.partition_writers[1].spill_file.is_some());
+        assert!(repartitioner.partition_writers[0].has_spill_file());
+        assert!(repartitioner.partition_writers[1].has_spill_file());
 
         // insert another batch after spilling
         repartitioner.insert_batch(batch.clone()).await.unwrap();

--- a/native/core/src/execution/shuffle/writers/buf_batch_writer.rs
+++ b/native/core/src/execution/shuffle/writers/buf_batch_writer.rs
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::execution::shuffle::ShuffleBlockWriter;
+use arrow::array::RecordBatch;
+use datafusion::physical_plan::metrics::Time;
+use std::borrow::Borrow;
+use std::io::{Cursor, Seek, SeekFrom, Write};
+
+/// Write batches to writer while using a buffer to avoid frequent system calls.
+/// The record batches were first written by ShuffleBlockWriter into an internal buffer.
+/// Once the buffer exceeds the max size, the buffer will be flushed to the writer.
+pub(crate) struct BufBatchWriter<S: Borrow<ShuffleBlockWriter>, W: Write> {
+    shuffle_block_writer: S,
+    writer: W,
+    buffer: Vec<u8>,
+    buffer_max_size: usize,
+}
+
+impl<S: Borrow<ShuffleBlockWriter>, W: Write> BufBatchWriter<S, W> {
+    pub(crate) fn new(shuffle_block_writer: S, writer: W, buffer_max_size: usize) -> Self {
+        Self {
+            shuffle_block_writer,
+            writer,
+            buffer: vec![],
+            buffer_max_size,
+        }
+    }
+
+    pub(crate) fn write(
+        &mut self,
+        batch: &RecordBatch,
+        encode_time: &Time,
+        write_time: &Time,
+    ) -> datafusion::common::Result<usize> {
+        let mut cursor = Cursor::new(&mut self.buffer);
+        cursor.seek(SeekFrom::End(0))?;
+        let bytes_written =
+            self.shuffle_block_writer
+                .borrow()
+                .write_batch(batch, &mut cursor, encode_time)?;
+        let pos = cursor.position();
+        if pos >= self.buffer_max_size as u64 {
+            let mut write_timer = write_time.timer();
+            self.writer.write_all(&self.buffer)?;
+            write_timer.stop();
+            self.buffer.clear();
+        }
+        Ok(bytes_written)
+    }
+
+    pub(crate) fn flush(&mut self, write_time: &Time) -> datafusion::common::Result<()> {
+        let mut write_timer = write_time.timer();
+        if !self.buffer.is_empty() {
+            self.writer.write_all(&self.buffer)?;
+        }
+        self.writer.flush()?;
+        write_timer.stop();
+        self.buffer.clear();
+        Ok(())
+    }
+}
+
+impl<S: Borrow<ShuffleBlockWriter>, W: Write + Seek> BufBatchWriter<S, W> {
+    pub(crate) fn writer_stream_position(&mut self) -> datafusion::common::Result<u64> {
+        self.writer.stream_position().map_err(Into::into)
+    }
+}

--- a/native/core/src/execution/shuffle/writers/mod.rs
+++ b/native/core/src/execution/shuffle/writers/mod.rs
@@ -15,13 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub(crate) mod codec;
-mod comet_partitioning;
-mod metrics;
-mod shuffle_writer;
-pub mod spark_unsafe;
-mod writers;
+mod buf_batch_writer;
+mod partition_writer;
 
-pub use codec::{read_ipc_compressed, CompressionCodec, ShuffleBlockWriter};
-pub use comet_partitioning::CometPartitioning;
-pub use shuffle_writer::ShuffleWriterExec;
+pub(super) use buf_batch_writer::BufBatchWriter;
+pub(super) use partition_writer::PartitionWriter;

--- a/native/core/src/execution/shuffle/writers/partition_writer.rs
+++ b/native/core/src/execution/shuffle/writers/partition_writer.rs
@@ -1,0 +1,122 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::execution::shuffle::metrics::ShufflePartitionerMetrics;
+use crate::execution::shuffle::shuffle_writer::PartitionedBatchIterator;
+use crate::execution::shuffle::writers::buf_batch_writer::BufBatchWriter;
+use crate::execution::shuffle::ShuffleBlockWriter;
+use datafusion::common::DataFusionError;
+use datafusion::execution::disk_manager::RefCountedTempFile;
+use datafusion::execution::runtime_env::RuntimeEnv;
+use std::fs::{File, OpenOptions};
+
+struct SpillFile {
+    temp_file: RefCountedTempFile,
+    file: File,
+}
+
+pub(crate) struct PartitionWriter {
+    /// Spill file for intermediate shuffle output for this partition. Each spill event
+    /// will append to this file and the contents will be copied to the shuffle file at
+    /// the end of processing.
+    spill_file: Option<SpillFile>,
+    /// Writer that performs encoding and compression
+    shuffle_block_writer: ShuffleBlockWriter,
+}
+
+impl PartitionWriter {
+    pub(crate) fn try_new(
+        shuffle_block_writer: ShuffleBlockWriter,
+    ) -> datafusion::common::Result<Self> {
+        Ok(Self {
+            spill_file: None,
+            shuffle_block_writer,
+        })
+    }
+
+    fn ensure_spill_file_created(
+        &mut self,
+        runtime: &RuntimeEnv,
+    ) -> datafusion::common::Result<()> {
+        if self.spill_file.is_none() {
+            // Spill file is not yet created, create it
+            let spill_file = runtime
+                .disk_manager
+                .create_tmp_file("shuffle writer spill")?;
+            let spill_data = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(spill_file.path())
+                .map_err(|e| {
+                    DataFusionError::Execution(format!("Error occurred while spilling {e}"))
+                })?;
+            self.spill_file = Some(SpillFile {
+                temp_file: spill_file,
+                file: spill_data,
+            });
+        }
+        Ok(())
+    }
+
+    pub(crate) fn spill(
+        &mut self,
+        iter: &mut PartitionedBatchIterator,
+        runtime: &RuntimeEnv,
+        metrics: &ShufflePartitionerMetrics,
+        write_buffer_size: usize,
+    ) -> datafusion::common::Result<usize> {
+        if let Some(batch) = iter.next() {
+            self.ensure_spill_file_created(runtime)?;
+
+            let total_bytes_written = {
+                let mut buf_batch_writer = BufBatchWriter::new(
+                    &mut self.shuffle_block_writer,
+                    &mut self.spill_file.as_mut().unwrap().file,
+                    write_buffer_size,
+                );
+                let mut bytes_written =
+                    buf_batch_writer.write(&batch?, &metrics.encode_time, &metrics.write_time)?;
+                for batch in iter {
+                    let batch = batch?;
+                    bytes_written += buf_batch_writer.write(
+                        &batch,
+                        &metrics.encode_time,
+                        &metrics.write_time,
+                    )?;
+                }
+                buf_batch_writer.flush(&metrics.write_time)?;
+                bytes_written
+            };
+
+            Ok(total_bytes_written)
+        } else {
+            Ok(0)
+        }
+    }
+
+    pub(crate) fn path(&self) -> Option<&std::path::Path> {
+        self.spill_file
+            .as_ref()
+            .map(|spill_file| spill_file.temp_file.path())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_spill_file(&self) -> bool {
+        self.spill_file.is_some()
+    }
+}

--- a/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
+++ b/spark/src/main/scala/org/apache/comet/rules/EliminateRedundantTransitions.scala
@@ -155,7 +155,6 @@ case class EliminateRedundantTransitions(session: SparkSession) extends Rule[Spa
    * with such scans because the buffers may be modified after C2R reads them.
    *
    * This includes:
-   *   - CometScanExec with native_comet scan implementation (V1 path) - uses BatchReader
    *   - CometScanExec with native_iceberg_compat and partition columns - uses
    *     ConstantColumnReader
    *   - CometBatchScanExec with CometParquetScan (V2 Parquet path) - uses BatchReader
@@ -167,9 +166,8 @@ case class EliminateRedundantTransitions(session: SparkSession) extends Rule[Spa
       case _ =>
         op.exists {
           case scan: CometScanExec =>
-            scan.scanImpl == CometConf.SCAN_NATIVE_COMET ||
-            (scan.scanImpl == CometConf.SCAN_NATIVE_ICEBERG_COMPAT &&
-              scan.relation.partitionSchema.nonEmpty)
+            scan.scanImpl == CometConf.SCAN_NATIVE_ICEBERG_COMPAT &&
+            scan.relation.partitionSchema.nonEmpty
           case scan: CometBatchScanExec => scan.scan.isInstanceOf[CometParquetScan]
           case _ => false
         }

--- a/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
+++ b/spark/src/main/scala/org/apache/spark/sql/comet/CometNativeScanExec.scala
@@ -65,8 +65,16 @@ case class CometNativeScanExec(
   override val nodeName: String =
     s"CometNativeScan $relation ${tableIdentifier.map(_.unquotedString).getOrElse("")}"
 
-  override lazy val outputPartitioning: Partitioning =
-    UnknownPartitioning(originalPlan.inputRDD.getNumPartitions)
+  // exposed for testing
+  lazy val bucketedScan: Boolean = originalPlan.bucketedScan && !disableBucketedScan
+
+  override lazy val outputPartitioning: Partitioning = {
+    if (bucketedScan) {
+      originalPlan.outputPartitioning
+    } else {
+      UnknownPartitioning(originalPlan.inputRDD.getNumPartitions)
+    }
+  }
 
   override lazy val outputOrdering: Seq[SortOrder] = originalPlan.outputOrdering
 

--- a/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometExpressionSuite.scala
@@ -185,7 +185,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
-  test("basic data type support") {
+  // ignored: native_comet scan is no longer supported
+  ignore("basic data type support") {
     // this test requires native_comet scan due to unsigned u8/u16 issue
     withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET) {
       Seq(true, false).foreach { dictionaryEnabled =>
@@ -216,7 +217,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
-  test("uint data type support") {
+  // ignored: native_comet scan is no longer supported
+  ignore("uint data type support") {
     // this test requires native_comet scan due to unsigned u8/u16 issue
     withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET) {
       Seq(true, false).foreach { dictionaryEnabled =>
@@ -1503,7 +1505,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
-  test("round") {
+  // ignored: native_comet scan is no longer supported
+  ignore("round") {
     // https://github.com/apache/datafusion-comet/issues/1441
     assume(usingLegacyNativeCometScan)
     Seq(true, false).foreach { dictionaryEnabled =>
@@ -1567,7 +1570,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
-  test("hex") {
+  // ignored: native_comet scan is no longer supported
+  ignore("hex") {
     // https://github.com/apache/datafusion-comet/issues/1441
     assume(usingLegacyNativeCometScan)
     Seq(true, false).foreach { dictionaryEnabled =>
@@ -2781,7 +2785,8 @@ class CometExpressionSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     }
   }
 
-  test("test integral divide") {
+  // ignored: native_comet scan is no longer supported
+  ignore("test integral divide") {
     // this test requires native_comet scan due to unsigned u8/u16 issue
     withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET) {
       Seq(true, false).foreach { dictionaryEnabled =>

--- a/spark/src/test/scala/org/apache/comet/CometSqlFileTestSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/CometSqlFileTestSuite.scala
@@ -77,25 +77,31 @@ class CometSqlFileTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
     "spark.sql.optimizer.excludedRules" ->
       "org.apache.spark.sql.catalyst.optimizer.ConstantFolding")
 
-  private def runTestFile(file: SqlTestFile): Unit = {
+  private def runTestFile(relativePath: String, file: SqlTestFile): Unit = {
     val allConfigs = file.configs ++ constantFoldingExcluded
     withSQLConf(allConfigs: _*) {
       withTable(file.tables: _*) {
         file.records.foreach {
-          case SqlStatement(sql) =>
-            spark.sql(sql)
-          case SqlQuery(sql, mode) =>
-            mode match {
-              case CheckCoverageAndAnswer =>
-                checkSparkAnswerAndOperator(sql)
-              case SparkAnswerOnly =>
-                checkSparkAnswer(sql)
-              case WithTolerance(tol) =>
-                checkSparkAnswerWithTolerance(sql, tol)
-              case ExpectFallback(reason) =>
-                checkSparkAnswerAndFallbackReason(sql, reason)
-              case Ignore(reason) =>
-                logInfo(s"IGNORED query (${reason}): $sql")
+          case SqlStatement(sql, line) =>
+            val location = if (line > 0) s"$relativePath:$line" else relativePath
+            withClue(s"In SQL file $location, executing statement:\n$sql\n") {
+              spark.sql(sql)
+            }
+          case SqlQuery(sql, mode, line) =>
+            val location = if (line > 0) s"$relativePath:$line" else relativePath
+            withClue(s"In SQL file $location, executing query:\n$sql\n") {
+              mode match {
+                case CheckCoverageAndAnswer =>
+                  checkSparkAnswerAndOperator(sql)
+                case SparkAnswerOnly =>
+                  checkSparkAnswer(sql)
+                case WithTolerance(tol) =>
+                  checkSparkAnswerWithTolerance(sql, tol)
+                case ExpectFallback(reason) =>
+                  checkSparkAnswerAndFallbackReason(sql, reason)
+                case Ignore(reason) =>
+                  logInfo(s"IGNORED query (${reason}): $sql")
+              }
             }
         }
       }
@@ -118,7 +124,7 @@ class CometSqlFileTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
           logInfo(s"SKIPPED (requires Spark ${parsed.minSparkVersion.get}): $relativePath")
         } else {
           val effectiveConfigs = parsed.configs ++ combinations.headOption.getOrElse(Seq.empty)
-          runTestFile(parsed.copy(configs = effectiveConfigs))
+          runTestFile(relativePath, parsed.copy(configs = effectiveConfigs))
         }
       }
     } else {
@@ -129,7 +135,7 @@ class CometSqlFileTestSuite extends CometTestBase with AdaptiveSparkPlanHelper {
           if (skip) {
             logInfo(s"SKIPPED (requires Spark ${parsed.minSparkVersion.get}): $relativePath")
           } else {
-            runTestFile(parsed.copy(configs = parsed.configs ++ matrixConfigs))
+            runTestFile(relativePath, parsed.copy(configs = parsed.configs ++ matrixConfigs))
           }
         }
       }

--- a/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/exec/CometExecSuite.scala
@@ -382,7 +382,8 @@ class CometExecSuite extends CometTestBase {
     }
   }
 
-  test("ReusedExchangeExec should work on CometBroadcastExchangeExec with V2 scan") {
+  // ignored: native_comet scan is no longer supported
+  ignore("ReusedExchangeExec should work on CometBroadcastExchangeExec with V2 scan") {
     withSQLConf(
       CometConf.COMET_EXEC_BROADCAST_FORCE_ENABLED.key -> "true",
       CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET,

--- a/spark/src/test/scala/org/apache/comet/parquet/CometParquetWriterSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/CometParquetWriterSuite.scala
@@ -310,7 +310,8 @@ class CometParquetWriterSuite extends CometTestBase {
     }
   }
 
-  test("native write falls back when scan produces non-Arrow data") {
+  // ignored: native_comet scan is no longer supported
+  ignore("native write falls back when scan produces non-Arrow data") {
     // This test verifies that when a native scan (like native_comet) doesn't support
     // certain data types (complex types), the native write correctly falls back to Spark
     // instead of failing at runtime with "Comet execution only takes Arrow Arrays" error.

--- a/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/parquet/ParquetReadSuite.scala
@@ -85,7 +85,8 @@ abstract class ParquetReadSuite extends CometTestBase {
     }
   }
 
-  test("unsupported Spark types") {
+  // ignored: native_comet scan is no longer supported
+  ignore("unsupported Spark types") {
     // TODO this test is not correctly implemented for scan implementations other than SCAN_NATIVE_COMET
     // https://github.com/apache/datafusion-comet/issues/2188
     withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET) {
@@ -130,7 +131,8 @@ abstract class ParquetReadSuite extends CometTestBase {
     }
   }
 
-  test("unsupported Spark schema") {
+  // ignored: native_comet scan is no longer supported
+  ignore("unsupported Spark schema") {
     // TODO this test is not correctly implemented for scan implementations other than SCAN_NATIVE_COMET
     // https://github.com/apache/datafusion-comet/issues/2188
     withSQLConf(CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET) {
@@ -368,7 +370,8 @@ abstract class ParquetReadSuite extends CometTestBase {
     checkParquetFile(data)
   }
 
-  test("test multiple pages with different sizes and nulls") {
+  // ignored: native_comet scan is no longer supported
+  ignore("test multiple pages with different sizes and nulls") {
     def makeRawParquetFile(
         path: Path,
         dictionaryEnabled: Boolean,
@@ -1344,7 +1347,8 @@ abstract class ParquetReadSuite extends CometTestBase {
     }
   }
 
-  test("scan metrics") {
+  // ignored: native_comet scan is no longer supported
+  ignore("scan metrics") {
 
     val cometScanMetricNames = Seq(
       "ParquetRowGroups",
@@ -1866,8 +1870,7 @@ class ParquetReadV1Suite extends ParquetReadSuite with AdaptiveSparkPlanHelper {
 
   test("Test V1 parquet scan uses respective scanner") {
     Seq(
-      ("false", CometConf.SCAN_NATIVE_COMET, "FileScan parquet"),
-      ("true", CometConf.SCAN_NATIVE_COMET, "CometScan [native_comet] parquet"),
+      ("false", CometConf.SCAN_NATIVE_DATAFUSION, "FileScan parquet"),
       ("true", CometConf.SCAN_NATIVE_DATAFUSION, "CometNativeScan"),
       ("true", CometConf.SCAN_NATIVE_ICEBERG_COMPAT, "CometScan [native_iceberg_compat] parquet"))
       .foreach { case (cometEnabled, cometNativeScanImpl, expectedScanner) =>
@@ -2014,10 +2017,11 @@ class ParquetReadV1Suite extends ParquetReadSuite with AdaptiveSparkPlanHelper {
 
 }
 
+// ignored: native_comet scan is no longer supported
 class ParquetReadV2Suite extends ParquetReadSuite with AdaptiveSparkPlanHelper {
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
       pos: Position): Unit = {
-    super.test(testName, testTags: _*)(
+    super.ignore(testName, testTags: _*)(
       withSQLConf(
         SQLConf.USE_V1_SOURCE_LIST.key -> "",
         CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET) {
@@ -2040,7 +2044,8 @@ class ParquetReadV2Suite extends ParquetReadSuite with AdaptiveSparkPlanHelper {
     }
   }
 
-  test("Test V2 parquet scan uses respective scanner") {
+  // ignored: native_comet scan is no longer supported
+  ignore("Test V2 parquet scan uses respective scanner") {
     Seq(("false", "BatchScan"), ("true", "CometBatchScan")).foreach {
       case (cometEnabled, expectedScanner) =>
         testScanner(

--- a/spark/src/test/scala/org/apache/comet/rules/CometScanRuleSuite.scala
+++ b/spark/src/test/scala/org/apache/comet/rules/CometScanRuleSuite.scala
@@ -101,7 +101,8 @@ class CometScanRuleSuite extends CometTestBase {
     }
   }
 
-  test("CometScanRule should replace V2 BatchScanExec, but only when Comet is enabled") {
+  // ignored: native_comet scan is no longer supported
+  ignore("CometScanRule should replace V2 BatchScanExec, but only when Comet is enabled") {
     withTempPath { path =>
       createTestDataFrame.write.parquet(path.toString)
       withTempView("test_data") {

--- a/spark/src/test/scala/org/apache/spark/sql/benchmark/CometReadBenchmark.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/benchmark/CometReadBenchmark.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnVector
 
 import org.apache.comet.{CometConf, WithHdfsCluster}
-import org.apache.comet.CometConf.{SCAN_NATIVE_COMET, SCAN_NATIVE_DATAFUSION, SCAN_NATIVE_ICEBERG_COMPAT}
+import org.apache.comet.CometConf.{SCAN_NATIVE_DATAFUSION, SCAN_NATIVE_ICEBERG_COMPAT}
 import org.apache.comet.parquet.BatchReader
 
 /**
@@ -65,14 +65,6 @@ class CometReadBaseBenchmark extends CometBenchmarkBase {
 
         sqlBenchmark.addCase("SQL Parquet - Spark") { _ =>
           spark.sql(s"select $query from parquetV1Table").noop()
-        }
-
-        sqlBenchmark.addCase("SQL Parquet - Comet") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_NATIVE_SCAN_IMPL.key -> SCAN_NATIVE_COMET) {
-            spark.sql(s"select $query from parquetV1Table").noop()
-          }
         }
 
         sqlBenchmark.addCase("SQL Parquet - Comet Native DataFusion") { _ =>
@@ -175,21 +167,6 @@ class CometReadBaseBenchmark extends CometBenchmarkBase {
           }
         }
 
-        sqlBenchmark.addCase("SQL Parquet - Comet") { _ =>
-          withSQLConf(
-            "spark.memory.offHeap.enabled" -> "true",
-            "spark.memory.offHeap.size" -> "10g",
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_NATIVE_SCAN_IMPL.key -> SCAN_NATIVE_COMET,
-            DecryptionPropertiesFactory.CRYPTO_FACTORY_CLASS_PROPERTY_NAME -> cryptoFactoryClass,
-            KeyToolkit.KMS_CLIENT_CLASS_PROPERTY_NAME ->
-              "org.apache.parquet.crypto.keytools.mocks.InMemoryKMS",
-            InMemoryKMS.KEY_LIST_PROPERTY_NAME ->
-              s"footerKey: ${footerKey}, key1: ${key1}") {
-            spark.sql(s"select $query from parquetV1Table").noop()
-          }
-        }
-
         sqlBenchmark.addCase("SQL Parquet - Comet Native DataFusion") { _ =>
           withSQLConf(
             "spark.memory.offHeap.enabled" -> "true",
@@ -243,14 +220,6 @@ class CometReadBaseBenchmark extends CometBenchmarkBase {
 
         sqlBenchmark.addCase("SQL Parquet - Spark") { _ =>
           spark.sql("select sum(id) from parquetV1Table").noop()
-        }
-
-        sqlBenchmark.addCase("SQL Parquet - Comet") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_NATIVE_SCAN_IMPL.key -> SCAN_NATIVE_COMET) {
-            spark.sql("select sum(id) from parquetV1Table").noop()
-          }
         }
 
         sqlBenchmark.addCase("SQL Parquet - Comet Native DataFusion") { _ =>
@@ -373,14 +342,6 @@ class CometReadBaseBenchmark extends CometBenchmarkBase {
           spark.sql("select sum(c2) from parquetV1Table where c1 + 1 > 0").noop()
         }
 
-        benchmark.addCase("SQL Parquet - Comet") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_NATIVE_SCAN_IMPL.key -> SCAN_NATIVE_COMET) {
-            spark.sql("select sum(c2) from parquetV1Table where c1 + 1 > 0").noop()
-          }
-        }
-
         benchmark.addCase("SQL Parquet - Comet Native DataFusion") { _ =>
           withSQLConf(
             CometConf.COMET_ENABLED.key -> "true",
@@ -431,14 +392,6 @@ class CometReadBaseBenchmark extends CometBenchmarkBase {
           spark.sql("select sum(length(id)) from parquetV1Table").noop()
         }
 
-        sqlBenchmark.addCase("SQL Parquet - Comet") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_NATIVE_SCAN_IMPL.key -> SCAN_NATIVE_COMET) {
-            spark.sql("select sum(length(id)) from parquetV1Table").noop()
-          }
-        }
-
         sqlBenchmark.addCase("SQL Parquet - Comet Native DataFusion") { _ =>
           withSQLConf(
             CometConf.COMET_ENABLED.key -> "true",
@@ -480,17 +433,6 @@ class CometReadBaseBenchmark extends CometBenchmarkBase {
             .sql("select sum(length(c2)) from parquetV1Table where c1 is " +
               "not NULL and c2 is not NULL")
             .noop()
-        }
-
-        benchmark.addCase("SQL Parquet - Comet") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_NATIVE_SCAN_IMPL.key -> SCAN_NATIVE_COMET) {
-            spark
-              .sql("select sum(length(c2)) from parquetV1Table where c1 is " +
-                "not NULL and c2 is not NULL")
-              .noop()
-          }
         }
 
         benchmark.addCase("SQL Parquet - Comet Native DataFusion") { _ =>
@@ -538,14 +480,6 @@ class CometReadBaseBenchmark extends CometBenchmarkBase {
           spark.sql(s"SELECT sum(c$middle) FROM parquetV1Table").noop()
         }
 
-        benchmark.addCase("SQL Parquet - Comet") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_NATIVE_SCAN_IMPL.key -> SCAN_NATIVE_COMET) {
-            spark.sql(s"SELECT sum(c$middle) FROM parquetV1Table").noop()
-          }
-        }
-
         benchmark.addCase("SQL Parquet - Comet Native DataFusion") { _ =>
           withSQLConf(
             CometConf.COMET_ENABLED.key -> "true",
@@ -589,14 +523,6 @@ class CometReadBaseBenchmark extends CometBenchmarkBase {
           spark.sql("SELECT * FROM parquetV1Table WHERE c1 + 1 > 0").noop()
         }
 
-        benchmark.addCase("SQL Parquet - Comet") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_NATIVE_SCAN_IMPL.key -> SCAN_NATIVE_COMET) {
-            spark.sql("SELECT * FROM parquetV1Table WHERE c1 + 1 > 0").noop()
-          }
-        }
-
         benchmark.addCase("SQL Parquet - Comet Native DataFusion") { _ =>
           withSQLConf(
             CometConf.COMET_ENABLED.key -> "true",
@@ -638,14 +564,6 @@ class CometReadBaseBenchmark extends CometBenchmarkBase {
 
         benchmark.addCase("SQL Parquet - Spark") { _ =>
           spark.sql("SELECT * FROM parquetV1Table WHERE c1 + 1 > 0").noop()
-        }
-
-        benchmark.addCase("SQL Parquet - Comet") { _ =>
-          withSQLConf(
-            CometConf.COMET_ENABLED.key -> "true",
-            CometConf.COMET_NATIVE_SCAN_IMPL.key -> SCAN_NATIVE_COMET) {
-            spark.sql("SELECT * FROM parquetV1Table WHERE c1 + 1 > 0").noop()
-          }
         }
 
         benchmark.addCase("SQL Parquet - Comet Native DataFusion") { _ =>

--- a/spark/src/test/scala/org/apache/spark/sql/comet/ParquetDatetimeRebaseSuite.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/ParquetDatetimeRebaseSuite.scala
@@ -37,7 +37,8 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
   // visible under package `spark`.
   val SPARK_TESTING: String = "spark.testing"
 
-  test("reading ancient dates before 1582") {
+  // ignored: native_comet scan is no longer supported
+  ignore("reading ancient dates before 1582") {
     Seq(true, false).foreach { exceptionOnRebase =>
       withSQLConf(
         CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET,
@@ -62,7 +63,8 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
     }
   }
 
-  test("reading ancient timestamps before 1582") {
+  // ignored: native_comet scan is no longer supported
+  ignore("reading ancient timestamps before 1582") {
     assume(usingLegacyNativeCometScan(conf))
     Seq(true, false).foreach { exceptionOnRebase =>
       withSQLConf(
@@ -89,7 +91,8 @@ abstract class ParquetDatetimeRebaseSuite extends CometTestBase {
     }
   }
 
-  test("reading ancient int96 timestamps before 1582") {
+  // ignored: native_comet scan is no longer supported
+  ignore("reading ancient int96 timestamps before 1582") {
     assume(usingLegacyNativeCometScan(conf))
     Seq(true, false).foreach { exceptionOnRebase =>
       withSQLConf(
@@ -147,12 +150,11 @@ class ParquetDatetimeRebaseV1Suite extends ParquetDatetimeRebaseSuite {
   }
 }
 
+// ignored: native_comet scan is no longer supported
 class ParquetDatetimeRebaseV2Suite extends ParquetDatetimeRebaseSuite {
   override protected def test(testName: String, testTags: Tag*)(testFun: => Any)(implicit
       pos: Position): Unit = {
-    // Datasource V2 is not supported by the native (datafusion based) readers so force
-    // the scan impl back to 'native_comet'
-    super.test(testName, testTags: _*)(
+    super.ignore(testName, testTags: _*)(
       withSQLConf(
         SQLConf.USE_V1_SOURCE_LIST.key -> "",
         CometConf.COMET_NATIVE_SCAN_IMPL.key -> CometConf.SCAN_NATIVE_COMET) {

--- a/spark/src/test/scala/org/apache/spark/sql/comet/ParquetEncryptionITCase.scala
+++ b/spark/src/test/scala/org/apache/spark/sql/comet/ParquetEncryptionITCase.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SQLTestUtils
 
 import org.apache.comet.{CometConf, IntegrationTestSuite}
-import org.apache.comet.CometConf.{SCAN_NATIVE_COMET, SCAN_NATIVE_DATAFUSION, SCAN_NATIVE_ICEBERG_COMPAT}
+import org.apache.comet.CometConf.{SCAN_NATIVE_DATAFUSION, SCAN_NATIVE_ICEBERG_COMPAT}
 
 /**
  * A integration test suite that tests parquet modular encryption usage.
@@ -238,12 +238,7 @@ class ParquetEncryptionITCase extends CometTestBase with SQLTestUtils {
 
         // native_datafusion and native_iceberg_compat fall back due to Arrow-rs
         // https://github.com/apache/arrow-rs/blob/da9829728e2a9dffb8d4f47ffe7b103793851724/parquet/src/file/metadata/parser.rs#L494
-        if (CometConf.COMET_ENABLED.get(conf) && CometConf.COMET_NATIVE_SCAN_IMPL.get(
-            conf) == SCAN_NATIVE_COMET) {
-          checkSparkAnswerAndOperator(readDataset)
-        } else {
-          checkAnswer(readDataset, inputDF)
-        }
+        checkAnswer(readDataset, inputDF)
       }
     }
   }
@@ -442,12 +437,7 @@ class ParquetEncryptionITCase extends CometTestBase with SQLTestUtils {
 
         // native_datafusion and native_iceberg_compat fall back due to Arrow-rs not
         // supporting other key lengths
-        if (CometConf.COMET_ENABLED.get(conf) && CometConf.COMET_NATIVE_SCAN_IMPL.get(
-            conf) == SCAN_NATIVE_COMET) {
-          checkSparkAnswerAndOperator(readDataset)
-        } else {
-          checkAnswer(readDataset, inputDF)
-        }
+        checkAnswer(readDataset, inputDF)
       }
     }
   }
@@ -467,17 +457,16 @@ class ParquetEncryptionITCase extends CometTestBase with SQLTestUtils {
 
     Seq("true", "false").foreach { cometEnabled =>
       if (cometEnabled == "true") {
-        Seq(SCAN_NATIVE_COMET, SCAN_NATIVE_DATAFUSION, SCAN_NATIVE_ICEBERG_COMPAT).foreach {
-          scanImpl =>
-            super.test(testName + s" Comet($cometEnabled)" + s" Scan($scanImpl)", testTags: _*) {
-              withSQLConf(
-                CometConf.COMET_ENABLED.key -> cometEnabled,
-                CometConf.COMET_EXEC_ENABLED.key -> "true",
-                SQLConf.ANSI_ENABLED.key -> "false",
-                CometConf.COMET_NATIVE_SCAN_IMPL.key -> scanImpl) {
-                testFun
-              }
+        Seq(SCAN_NATIVE_DATAFUSION, SCAN_NATIVE_ICEBERG_COMPAT).foreach { scanImpl =>
+          super.test(testName + s" Comet($cometEnabled)" + s" Scan($scanImpl)", testTags: _*) {
+            withSQLConf(
+              CometConf.COMET_ENABLED.key -> cometEnabled,
+              CometConf.COMET_EXEC_ENABLED.key -> "true",
+              SQLConf.ANSI_ENABLED.key -> "false",
+              CometConf.COMET_NATIVE_SCAN_IMPL.key -> scanImpl) {
+              testFun
             }
+          }
         }
       } else {
         super.test(testName + s" Comet($cometEnabled)", testTags: _*) {


### PR DESCRIPTION
## Summary
- Remove match arm and `nativeCometScan` method from `CometScanRule`
- Remove V2 ParquetScan handling for `native_comet`
- Remove unused `selectScan` method
- Simplify type checking in `CometScanTypeChecker` (remove native_comet-specific conditions)
- Remove `native_comet` mutable buffer check from `EliminateRedundantTransitions`

## Test plan
- [x] Compile succeeds
- [ ] Existing tests pass (native_comet is no longer a valid config option per #3358)

🤖 Generated with [Claude Code](https://claude.com/claude-code)